### PR TITLE
Change solution counter truncated message

### DIFF
--- a/dns-snmp-agent/BCN-DNS-AGENT-MIB.mib
+++ b/dns-snmp-agent/BCN-DNS-AGENT-MIB.mib
@@ -88,8 +88,7 @@ BcnDnsStatAgentQryTypes   ::= TEXTUAL-CONVENTION
 		bcnDnsStatAgentQryREFUSED(11),
 		bcnDnsStatAgentQryOtherRcode(12),
         bcnDnsStatAgentQrySuccessfulRecursive(13),
-        bcnDnsStatAgentQrySuccessfulNoauthAns(14),
-        bcnDnsStatAgentQryTruncated(15)
+        bcnDnsStatAgentQrySuccessfulNoauthAns(14)
     }
 
 BcnDnsBindStatPerViewAgentQryTypes   ::= TEXTUAL-CONVENTION
@@ -111,8 +110,7 @@ BcnDnsBindStatPerViewAgentQryTypes   ::= TEXTUAL-CONVENTION
 			QryRTT1600: Queries whose round trip times are between 800 (inclusive) and 1600 (exclusive) milliseconds.
 			QryRTT1600Plus: Queries whose round trip times are equal to or over 1600 milliseconds.
 			QryREFUSED: Queries that resulted in REFUSED responses
-			QryOtherError: Queries that resulted in an error that was not NXDOMAIN, SERVFAIL, FORMERR or REFUSED.
-            QryTruncated: Queries that resulted in TRUNCATE responses"
+			QryOtherError: Queries that resulted in an error that was not NXDOMAIN, SERVFAIL, FORMERR or REFUSED."
     SYNTAX  Integer32 {
         bcnStatAgentViewTotalQueries(1),
         bcnStatAgentViewTotalResponses(2),

--- a/dns-snmp-agent/common/constants.py
+++ b/dns-snmp-agent/common/constants.py
@@ -53,8 +53,7 @@ class QryType():
         "refused": 11,
         "other_rcode": 12,
         "successful_recursive": 13,
-        "successful_noauthans": 14,
-        "truncated": 15
+        "successful_noauthans": 14
     }
     METRIC_FOR_BIND_VIEW = {
         "totalQueries": 1,

--- a/dns-snmp-agent/test/test_mock.py
+++ b/dns-snmp-agent/test/test_mock.py
@@ -38,8 +38,7 @@ payload = {
 		  "other_rcode": 0,
 		  "average_time": 0.1444,
 		  "successful_recursive": 12,
-		  "successful_noauthans": 0,
-		  "truncated": 10
+		  "successful_noauthans": 0
 	    }
   	},
   	"192.168.88.123": {
@@ -59,8 +58,7 @@ payload = {
 		  "other_rcode": 0,
 		  "average_time": 4.112,
 		  "successful_recursive": 0,
-		  "successful_noauthans": 30,
-		  "truncated": 0
+		  "successful_noauthans": 30
 	    }
   	},
 	"view_2": {
@@ -80,8 +78,7 @@ payload = {
 			"average_time": 0.22,
 			"other_rcode": 0,
 			"successful_recursive": 0,
-		  	"successful_noauthans": 0,
-			"truncated": 10
+		  	"successful_noauthans": 0
       	}
     }
   }

--- a/dns-snmp-agent/test/test_perf.py
+++ b/dns-snmp-agent/test/test_perf.py
@@ -47,8 +47,7 @@ for count in range(int(number_client)):
                 "other_rcode": 10,
                 "average_time": 0.115,
                 "successful_recursive": 12,
-                "successful_noauthans": 0,
-                "truncated": 1
+                "successful_noauthans": 0
             }
         }
     })

--- a/packetbeat/statsdns/statistics_dns.go
+++ b/packetbeat/statsdns/statistics_dns.go
@@ -741,3 +741,14 @@ func HandleResponseDecodeErr(clientIP, srvIP string, RCodeString string) {
 		}
 	}
 }
+
+func HandleResponseTruncated(clientIP, srvIP string) {
+	if !utils.IsInternalCall(clientIP, srvIP) {
+		if !utils.IsLocalIP(clientIP) {
+			IncrDNSStatsSuccessful(clientIP)
+			IncrDNSStatsSuccessfulForPerView(clientIP, CLIENT)
+			IncrDNSStatsTotalResponses(clientIP)
+			ResponseForPerView(clientIP)
+		}
+	}
+}


### PR DESCRIPTION
Issue:
- Packetbeat: counter OtherRCode and NXRRSET when received truncated message
Output: {"total_queries":2,"total_responses":2,"recursive":0,"successful_recursive":0,"successful_noauthans":0,"duplicated":0,"average_time":0.119,"successful":1,"server_fail":0,"nx_domain":0,"format_error":0,"nx_rrset":1,"referral":0,"refused":0,"other_rcode":1}

New changes:
- dns-snmp-agent: Remove truncated type (remove changes in #4)
- Packetbeat: 
Output example:{"total_queries":2,"total_responses":2,"recursive":0,"successful_recursive":0,"successful_noauthans":0,"duplicated":0,"average_time":0.11375,"successful":2,"server_fail":0,"nx_domain":0,"format_error":0,"nx_rrset":0,"referral":0,"refused":0,"other_rcode":0}