### PR TITLE
Release v2.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,15 @@ jobs:
             export GOPATH=$HOME/gocode
             go version
             go env
+            ls -la $GOPATH/src/github.com/elastic/beats/vendor/github.com/tsg
+            echo "Check old gopacket"
+            cat $GOPATH/src/github.com/elastic/beats/vendor/github.com/tsg/gopacket/afpacket/afpacket.go
+            echo "Remove old gopacket"
+            rm -rf $GOPATH/src/github.com/elastic/beats/vendor/github.com/tsg/gopacket
             cd $GOPATH/src/github.com/elastic/beats/packetbeat
             go get -t -d -v ./...
+            echo "Check new gopacket"
+            cat $GOPATH/src/github.com/tsg/gopacket/afpacket/afpacket.go
             go build
       - run:
           name: Prepare to public

--- a/packetbeat/beater/version.go
+++ b/packetbeat/beater/version.go
@@ -17,5 +17,5 @@ package beater
 
 const (
 	// Version is packetbeat bluecat implement
-	Version = "v2.7.3 debug.1(Beat 6.5.4)"
+	Version = "v2.7.3 debug.2(Beat 6.5.4)"
 )

--- a/packetbeat/beater/version.go
+++ b/packetbeat/beater/version.go
@@ -17,5 +17,5 @@ package beater
 
 const (
 	// Version is packetbeat bluecat implement
-	Version = "v2.7.3 (Beat 6.5.4)"
+	Version = "v2.7.3 debug.1(Beat 6.5.4)"
 )

--- a/packetbeat/beater/version.go
+++ b/packetbeat/beater/version.go
@@ -17,5 +17,5 @@ package beater
 
 const (
 	// Version is packetbeat bluecat implement
-	Version = "v2.7.3 debug.2(Beat 6.5.4)"
+	Version = "v2.7.4 (Beat 6.5.4)"
 )

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -356,7 +356,6 @@ func (dns *dnsPlugin) receivedDNSRequest(tuple *dnsTuple, msg *dnsMessage) {
 		dns.deleteTransaction(trans.tuple.hashable())
 	}
 
-	logp.Info("Request infor: srcIP=%v - dstIP=%v reqID=%d - time=%s - question=%v", srcIP, dstIP, msg.data.MsgHdr.Id, msg.ts, msg.data.Question)
 	//Bluecat
 	queryDNS := statsdns.NewQueryDNS(srcIP, dstIP, isDuplicated)
 	statsdns.QStatDNS.PushQueryDNS(queryDNS)

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -356,6 +356,7 @@ func (dns *dnsPlugin) receivedDNSRequest(tuple *dnsTuple, msg *dnsMessage) {
 		dns.deleteTransaction(trans.tuple.hashable())
 	}
 
+	logp.Info("Request infor: srcIP=%v - dstIP=%v reqID=%d - time=%s - question=%v", srcIP, dstIP, msg.data.MsgHdr.Id, msg.ts, msg.data.Question)
 	//Bluecat
 	queryDNS := statsdns.NewQueryDNS(srcIP, dstIP, isDuplicated)
 	statsdns.QStatDNS.PushQueryDNS(queryDNS)


### PR DESCRIPTION
- Update config file of Circle CI to build packetbeat which use the latest commit tsg/gopacket library instead of commit 8e703b9968693c15f25cabb6ba8be4370cf431d0 (Using default in beat 6.5.4)
- Set version 2.7.4