### PR TITLE
Release Packetbeat v2.8.0: Update new solution for auto update named' data

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Extract the dns-traffic-statistic-agent.tar.gz to a folder in BDDS, then follow 
 | statistics_destination  | http://[IP]:[PORT]/counter [String]  | IP and PORT of SNMP Sub Agent Http Server
 | statistics_interval  | [integer]  | Interval collecting and sending DNS statistics
 | maximum_clients  | [integer]  | maximum number of clients for statistics, 200 clients is required.
-| url_announcement_bam_deploy  | http://[IP]:[PORT]/announcement-deploy-from-bam  |  IP and PORT of SNMP Sub Agent Http Server
+| url_announcement_bam_deploy  | "announcement-deploy-from-bam"  |  URL is called to Packetbeat HTTP server for updating ACL and matched clients for views from named config
+| http_server_address  | [IP]:[PORT]  |  IP and PORT of Packetbeat HTTP Server to listen on announcement deployed from BAM.
 | interval_clear_outstatis_cache  | [integer]  |  Interval In Second for cleaning data cached of data statistics which are sending to SNMP Agent
 
 ## SNMP Subagent installation and usage
@@ -85,11 +86,6 @@ Extract the dns-traffic-statistic-agent.tar.gz to a folder in BDDS, then follow 
 
 2. Configure snmpd.conf. There are 2 options:
 	- Enable and config snmp's information in BAM and deploy to BDDS.
-	- Copy snmpd.conf from dns-snmp-agent/ to /etc/snmpd/ and restart snmp service.
-		Note: Run following cmd to prevent snmpd.conf be overwritten automatically via BAM or when snmpd service is restarted:
-		```
-		/usr/local/bluecat/PsmClient node set manual-override=snmp
-		```
 
 3. Configure Master agent to plugin new sub-agent
 - Before running python dns_stat_agent, need to configuare AGENT_CONFIGURATION in config.py matched host and port in snmpd.conf.

--- a/packetbeat/announcement_bam_deploy.py
+++ b/packetbeat/announcement_bam_deploy.py
@@ -14,7 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""[Announcement_bam_deploy]
+Send HTTS's request to reload Named after BDDS receive deploy from BAM
+Informations(IP, port) need match with:
+    - Agent: config.py in dns-snmp-agent
+    - Packetbeat: statistics_config.json
+"""
 import httplib
-conn = httplib.HTTPConnection("127.0.0.1", 51415)
-conn.request("GET", "/announcement-deploy-from-bam")
 
+# Request to Agent HTTP
+try:
+    conn = httplib.HTTPConnection("127.0.0.1", 51415)
+    conn.request("GET", "/announcement-deploy-from-bam")
+except Exception as ex:
+    pass
+
+# Request to Packetbeat HTTP server
+try:
+    conn = httplib.HTTPConnection("127.0.0.1", 51416)
+    conn.request("GET", "/announcement-deploy-from-bam")
+except Exception as ex:
+    pass

--- a/packetbeat/beater/version.go
+++ b/packetbeat/beater/version.go
@@ -17,5 +17,5 @@ package beater
 
 const (
 	// Version is packetbeat bluecat implement
-	version = "v2.8 (Beat 6.5.4)"
+	Version = "v2.8.0 (Beat 6.5.4)"
 )

--- a/packetbeat/beater/version.go
+++ b/packetbeat/beater/version.go
@@ -17,5 +17,5 @@ package beater
 
 const (
 	// Version is packetbeat bluecat implement
-	Version = "v2.7.6 (Beat 6.5.4)"
+	version = "v2.8 (Beat 6.5.4)"
 )

--- a/packetbeat/config_statistics/config_statistics.go
+++ b/packetbeat/config_statistics/config_statistics.go
@@ -32,6 +32,7 @@ type ConfigStatistics struct {
 	StatisticsInterval           time.Duration `json:"statistics_interval"`
 	MaximumClients               int           `json:"maximum_clients"`
 	UrlAnnouncementDeployFromBam string        `json:"url_announcement_bam_deploy"`
+	StatHTTPServerAddr			 string        `json:"http_server_address"`
 	IntervalClearOutStatisCache  int           `json:"interval_clear_outstatis_cache"`
 }
 
@@ -107,7 +108,7 @@ func ReadACLInNamedConfig() ([]*net.IPNet, []*net.IPNet, []string, []string, map
 			switch {
 			case strings.Contains(line, FORMAT_MATCH_CLIENTS):
 				arrayIPsString := getArrayStringFromLineRecursive(line)
-				logp.Info("Ip Array %v", arrayIPsString)
+				logp.Debug("ReadACLInNamedConfig", "Ip Array %v", arrayIPsString)
 				for _, value := range arrayIPsString {
 					trimedValue := strings.TrimSpace(value)
 					//Normal case
@@ -146,7 +147,7 @@ func ReadACLInNamedConfig() ([]*net.IPNet, []*net.IPNet, []string, []string, map
 }
 
 func CollectMapACL() {
-	logp.Info("Starting collect ACL")
+	logp.Debug("CollectMapACL", "Starting collect ACL")
 	ACLMap = make(map[string][]string, 0)
 	file, err := os.Open(NAMED_CONFIG_PATH)
 	if err == nil {
@@ -165,7 +166,7 @@ func CollectMapACL() {
 	} else {
 		logp.Err("named.conf file doesn't exist: %v", err.Error())
 	}
-	logp.Info("Done collect ACL")
+	logp.Debug("CollectMapACL", "Done collect ACL")
 }
 
 func getIPsInLine(line string) (IPRangesInACL []*net.IPNet, IPsInACL []string) {

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -65,10 +65,10 @@ packetbeat.protocols:
   # (additional resource records) is added to messages.
   include_additionals: true
 
-- type: http
-  # Configure the ports where to listen for HTTP traffic. You can disable
-  # the HTTP protocol by commenting out the list of ports.
-  ports: [51415]
+# - type: http
+#   # Configure the ports where to listen for HTTP traffic. You can disable
+#   # the HTTP protocol by commenting out the list of ports.
+#   ports: [51415]
 
 # - type: memcache
 #   # Configure the ports where to listen for memcache traffic. You can disable

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/elastic/beats/packetbeat/procs"
 	"github.com/elastic/beats/packetbeat/protos"
-	"github.com/elastic/beats/packetbeat/statsdns"
 )
 
 var debugf = logp.MakeDebug("http")
@@ -236,12 +235,6 @@ func (http *httpPlugin) Parse(
 	private protos.ProtocolData,
 ) protos.ProtocolData {
 	defer logp.Recover("ParseHttp exception")
-
-	//[Bluecat]
-	//TODO: Capturing packet local HTTP Request For Updating Network Ips Range Of Statistics DNS
-	//logp.Info("Payload Parse: [%s]", pkt.Payload)
-	statsdns.ReceiveHttpRequest(string(pkt.Payload))
-
 	conn := ensureHTTPConnection(private)
 	conn = http.doParse(conn, pkt, tcptuple, dir)
 	if conn == nil {

--- a/packetbeat/statistics_config.json
+++ b/packetbeat/statistics_config.json
@@ -1,7 +1,8 @@
 {
-    "statistics_destination": "http://127.0.0.1:51415/counter", 
+    "statistics_destination": "http://127.0.0.1:51415/counter",
     "statistics_interval": 60,
     "maximum_clients": 200,
-    "url_announcement_bam_deploy":"http://127.0.0.1:51415/announcement-deploy-from-bam",
+    "url_announcement_bam_deploy":"announcement-deploy-from-bam",
+    "http_server_address": "127.0.0.1:51416",
     "interval_clear_outstatis_cache": 180
 }

--- a/packetbeat/statsdns/stat_http_server.go
+++ b/packetbeat/statsdns/stat_http_server.go
@@ -1,0 +1,38 @@
+// Copyright 2020 BlueCat Networks (USA) Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsdns
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func reqAnnouncementDeployFromBam(w http.ResponseWriter, req *http.Request) {
+	logp.Debug("HTTP server", "Receive AnnouncementDeployFromBam request")
+	ReloadNamedData()
+}
+
+func onLoadHTTPServer() {
+	uriAnnouncementFromBam := fmt.Sprintf("/%v", UrlAnnouncementDeployFromBam)
+	logp.Debug("onLoadHTTPServer", "Start Statistic HTTP server")
+	// Receive request when postDeploy send request AnnouncementDeployFromBam
+	http.HandleFunc(uriAnnouncementFromBam, reqAnnouncementDeployFromBam)
+	if err := http.ListenAndServe(StatHTTPServerAddr, nil); err != nil {
+		panic(err)
+		logp.Err("onLoadHTTPServer", err)
+	}
+}

--- a/packetbeat/statsdns/statistics_dns.go
+++ b/packetbeat/statsdns/statistics_dns.go
@@ -109,10 +109,16 @@ var (
 	MapViewIPs                   map[int]map[string][]string
 	QStatDNS                     *QueueStatDNS
 	IsActive                     bool
+	StatHTTPServerAddr           string
 )
 
 func InitStatisticsDNS() {
+	// Get data from statistics_config.json
 	GetConfigDNSStatistics()
+	// Update ACL client, server and MapViewIPs
+	ReloadNamedData()
+	// Start HTTP server
+	go onLoadHTTPServer()
 	// Create chan for management Statistic DNS counter
 	QStatDNS = NewQueueStatDNS()
 	QStatDNS.isPopWait = true
@@ -159,7 +165,6 @@ func Stop() {
 	IsActive = false
 	QStatDNS.Stop()
 }
-
 
 func onLoadReqMaps() {
 	// Load default RequestMap in ReqMaps array
@@ -673,9 +678,12 @@ func GetConfigDNSStatistics() {
 	config_statistics.Init()
 	StatInterval = config_statistics.ConfigStat.StatisticsInterval
 	MaximumClients = config_statistics.ConfigStat.MaximumClients
-	UrlAnnouncementDeployFromBam = strings.Replace(config_statistics.ConfigStat.UrlAnnouncementDeployFromBam, "http://", "", -1)
+	StatHTTPServerAddr = config_statistics.ConfigStat.StatHTTPServerAddr
+	UrlAnnouncementDeployFromBam = config_statistics.ConfigStat.UrlAnnouncementDeployFromBam
+}
+
+func ReloadNamedData() {
 	//Read named.conf get ACL Ips Range
-	logp.Info("Reading ACL In Named Config")
 	IPServerRangesInACL, IPClientRangesInACL, IPsServerInACL, IPsClientInACL, MapViewIPsInMatchClients := config_statistics.ReadACLInNamedConfig()
 
 	IpNetsServer = IPServerRangesInACL
@@ -689,16 +697,6 @@ func GetConfigDNSStatistics() {
 	logp.Info("IP In ACL Server: %v", IpsServer)
 	logp.Info("IPs In ACL Client: %v", IpsClient)
 	logp.Info("Map View Client IPs %v", MapViewIPs)
-}
-
-func ReceiveHttpRequest(payloadString string) {
-	arraySplitUrlAnnouncementFromBam := strings.Split(UrlAnnouncementDeployFromBam, "/")
-	checkUri := strings.Contains(payloadString, arraySplitUrlAnnouncementFromBam[len(arraySplitUrlAnnouncementFromBam)-1])
-	checkHostPort := strings.Contains(payloadString, arraySplitUrlAnnouncementFromBam[0])
-	if checkUri && checkHostPort {
-		logp.Info("http request with payload %s", payloadString)
-		GetConfigDNSStatistics()
-	}
 }
 
 // Store all request messages into the corresponding map for Incoming messages and Outgoing messages
@@ -721,8 +719,8 @@ func AddRequestMsgMap(clientIP, srvIP string, reqID uint16, questions []mkdns.Qu
 			mutex.Lock()
 			// Make sure only the first received query will be added into the map
 			// The first received client's request will be counted as recursion in case recursion happened
-			if _, exist := ReqMaps[len(ReqMaps) - 1].RequestMessage[metricType][rqKey]; !exist {
-				ReqMaps[len(ReqMaps) - 1].RequestMessage[metricType][rqKey] = rqItem
+			if _, exist := ReqMaps[len(ReqMaps)-1].RequestMessage[metricType][rqKey]; !exist {
+				ReqMaps[len(ReqMaps)-1].RequestMessage[metricType][rqKey] = rqItem
 			}
 			mutex.Unlock()
 		}
@@ -753,7 +751,7 @@ func CalculateRecursiveMsg(clientIP, srvIP string, reqID uint16, questions []mkd
 			recursiveDNS := NewRecursiveDNS(clientIP, isSuccess)
 			QStatDNS.PushRecursiveDNS(recursiveDNS)
 			mutex.Lock()
-			for _, reqMap := range ReqMaps{
+			for _, reqMap := range ReqMaps {
 				delete(reqMap.RequestMessage[RQ_S_MAP], rqKey)
 				delete(reqMap.RequestMessage[RQ_C_MAP], rqKey)
 			}
@@ -772,7 +770,7 @@ func genKeyItem(question mkdns.Question) string {
 
 func existQuery(rqKey, rqItem, metricType string) bool {
 	existing := false
-	for _, reqMap := range ReqMaps{
+	for _, reqMap := range ReqMaps {
 		if value, exist := reqMap.RequestMessage[metricType][rqKey]; exist {
 			existing = value == rqItem
 			if existing {


### PR DESCRIPTION
The new solution, Packetbeat will start another HTTP server and we set send HTTP request to that at announcement_bam_deploy.py. After Packetbeat HTTP-server receive request, it will update named's data . Packetbeat will not capture traffic HTTP of agent as previous solution.
With new solution we need to change:
- Add python code send HTTP request to Packetbeat HTTP at /usr/share/packetbeat/bin/announcement_bam_deploy.py
- Update url_announcement_bam_deploy and add http_server_address at /usr/share/packetbeat/bin/statistics_config.json
  (that the configuration's packetbeat http server receive request from announcement_bam_deploy.py)
- Disable packetbeat.protocols type http in /etc/packetbeat/packetbeat.yml