### PR TITLE
Add extMatch for DNS State Rotation Logger

### DIFF
--- a/dns-snmp-agent/config.py
+++ b/dns-snmp-agent/config.py
@@ -66,6 +66,8 @@ else:
 handler = TimedRotatingFileHandler(
     LOG_PATH + "/" + LOG_NAME, when="midnight", interval=1)
 handler.suffix = "%Y%m%d"
+handler.extMatch = re.compile(r"^\d{4}\d{2}\d{2}$")
+
 log_formater = logging.Formatter("%(asctime)s:%(levelname)s:%(message)s")
 handler.setFormatter(log_formater)
 logger.addHandler(handler)

--- a/packetbeat/statsdns/statistics_dns.go
+++ b/packetbeat/statsdns/statistics_dns.go
@@ -156,7 +156,7 @@ func InitStatisticsDNS() {
 
 						number := 1
 						for Equal(currentLocalAddrs, LocalAddrs) {
-							if number > 30 {
+							if number > 60 {
 								break;
 							}
 


### PR DESCRIPTION
Fix issue when `when='midnight'` not working with the suffix is "%Y%m%d" with `extMatch`:
handler.extMatch = re.compile(r"^\d{4}\d{2}\d{2}$")
